### PR TITLE
Release v2.26.0

### DIFF
--- a/contract/Schrodinger/SchrodingerContractState.cs
+++ b/contract/Schrodinger/SchrodingerContractState.cs
@@ -71,4 +71,19 @@ public partial class SchrodingerContractState : ContractState
     
     // tick -> count
     public MappedState<string, long> VoucherIdCountMap { get; set; }
+    
+    // tick -> config
+    public MappedState<string, RerollConfig> RerollConfigMap { get; set; }
+    
+    // tick -> MergeConfig
+    public MappedState<string, MergeConfig> MergeConfigMap { get; set; }
+    
+    // tick -> level -> rate
+    public MappedState<string, long, long> MergeRatesMap { get; set; }
+
+    // tick -> maximumLevel
+    public MappedState<string, long> MaximumLevelMap { get; set; }
+    
+    // tick -> VoucherAdoptionConfig
+    public MappedState<string, VoucherAdoptionConfig> VoucherAdoptionConfigMap { get; set; }
 }

--- a/contract/Schrodinger/SchrodingerContract_Airdrop.cs
+++ b/contract/Schrodinger/SchrodingerContract_Airdrop.cs
@@ -16,8 +16,7 @@ public partial class SchrodingerContract
         Assert(input.List != null && input.List.Count > 0, "Invalid list.");
         Assert(input.Amount > 0, "Invalid amount.");
 
-        var inscriptionInfo = State.InscriptionInfoMap[input.Tick];
-        Assert(inscriptionInfo != null, "Tick not deployed.");
+        var inscriptionInfo = GetInscriptionInfo(input.Tick);
 
         var controller = State.AirdropControllerMap[input.Tick];
         Assert(

--- a/contract/Schrodinger/SchrodingerContract_Helper.cs
+++ b/contract/Schrodinger/SchrodingerContract_Helper.cs
@@ -56,6 +56,12 @@ public partial class SchrodingerContract
     {
         return symbol.Split(SchrodingerContractConstants.Separator)[0].ToUpper();
     }
+    
+    private long GetNumberFromSymbol(string symbol)
+    {
+        long.TryParse(symbol.Split(SchrodingerContractConstants.Separator)[1], out var result);
+        return result;
+    }
 
     private InscriptionInfo CheckInscriptionExistAndPermission(string tick)
     {
@@ -70,6 +76,14 @@ public partial class SchrodingerContract
         return State.InscriptionInfoMap[tick] == null
             ? new Address()
             : Context.ConvertVirtualAddressToContractAddress(HashHelper.ComputeFrom(tick));
+    }
+
+    private InscriptionInfo GetInscriptionInfo(string tick)
+    {
+        var inscriptionInfo = State.InscriptionInfoMap[tick];
+        Assert(inscriptionInfo != null, "Inscription not found.");
+        
+        return inscriptionInfo;
     }
 
     #region Deploy

--- a/contract/Schrodinger/SchrodingerContract_InscriptionConfig.cs
+++ b/contract/Schrodinger/SchrodingerContract_InscriptionConfig.cs
@@ -192,6 +192,34 @@ public partial class SchrodingerContract
         return new Empty();
     }
 
+    public override Empty SetRerollConfig(SetRerollConfigInput input)
+    {
+        Assert(input != null, "Invalid input.");
+        Assert(IsStringValid(input!.Tick), "Invalid tick.");
+        Assert(input.Rate >= 0, "Invalid rate.");
+        Assert(input.Index > 0, "Invalid index.");
+
+        CheckInscriptionExistAndPermission(input.Tick);
+
+        var config = new RerollConfig
+        {
+            Rate = input.Rate,
+            Index = input.Index
+        };
+
+        if (config.Equals(State.RerollConfigMap[input.Tick])) return new Empty();
+
+        State.RerollConfigMap[input.Tick] = config;
+
+        Context.Fire(new RerollConfigSet
+        {
+            Tick = input.Tick,
+            Config = config
+        });
+
+        return new Empty();
+    }
+
     private void FireRandomAttributeSetLogEvent(AttributeInfo toRemove, AttributeSet attributeSet)
     {
         var logEvent = new RandomAttributeSet();

--- a/contract/Schrodinger/SchrodingerContract_Merge.cs
+++ b/contract/Schrodinger/SchrodingerContract_Merge.cs
@@ -1,0 +1,246 @@
+using System.Collections.Generic;
+using System.Linq;
+using AElf;
+using AElf.Contracts.MultiToken;
+using AElf.CSharp.Core;
+using AElf.Sdk.CSharp;
+using AElf.Types;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Schrodinger;
+
+public partial class SchrodingerContract
+{
+    public override Empty SetMergeRatesConfig(SetMergeRatesConfigInput input)
+    {
+        Assert(input != null, "Invalid input.");
+        Assert(IsStringValid(input!.Tick), "Invalid tick.");
+        Assert(input.MergeRates != null && input.MergeRates.Count > 0, "Invalid merge rates.");
+        Assert(input.MaximumLevel > 0, "Invalid maximum level.");
+
+        CheckInscriptionExistAndPermission(input.Tick);
+
+        State.MaximumLevelMap[input.Tick] = input.MaximumLevel;
+
+        var mergeRates = new List<MergeRate>();
+
+        foreach (var mergeRate in input.MergeRates!.Distinct().ToList())
+        {
+            if (mergeRate.Level > input.MaximumLevel) continue;
+
+            Assert(mergeRate.Rate >= 0, "Invalid merge rate.");
+
+            mergeRates.Add(mergeRate);
+            State.MergeRatesMap[input.Tick][mergeRate.Level] = mergeRate.Rate;
+        }
+
+        Context.Fire(new MergeRatesConfigSet
+        {
+            MergeRates = new MergeRates { Data = { mergeRates } },
+            Tick = input.Tick,
+            MaximumLevel = input.MaximumLevel
+        });
+
+        return new Empty();
+    }
+
+    public override Empty SetMergeConfig(SetMergeConfigInput input)
+    {
+        Assert(input != null, "Invalid input.");
+        Assert(IsStringValid(input!.Tick), "Invalid tick.");
+        Assert(input.CommissionAmount >= 0, "Invalid commission amount.");
+        Assert(input.PoolAmount >= 0, "Invalid pool amount.");
+
+        CheckInscriptionExistAndPermission(input.Tick);
+
+        var config = new MergeConfig
+        {
+            CommissionAmount = input.CommissionAmount,
+            PoolAmount = input.PoolAmount
+        };
+
+        if (config.Equals(State.MergeConfigMap[input.Tick])) return new Empty();
+
+        State.MergeConfigMap[input.Tick] = config;
+
+        Context.Fire(new MergeConfigSet
+        {
+            Tick = input.Tick,
+            Config = config
+        });
+
+        return new Empty();
+    }
+
+    public override Empty Merge(MergeInput input)
+    {
+        Assert(input != null, "Invalid input.");
+        Assert(IsStringValid(input!.Tick), "Invalid tick.");
+        Assert(IsHashValid(input.AdoptIdA), "Invalid adopt id a.");
+        Assert(IsHashValid(input.AdoptIdB), "Invalid adopt id b.");
+        Assert(input.Level > 0, "Invalid level.");
+        Assert(!input.Signature.IsNullOrEmpty(), "Invalid signature.");
+
+        Assert(
+            RecoverAddressFromSignature(ComputeMergeInputHash(input), input.Signature) ==
+            State.SignatoryMap[input.Tick], "Invalid signature.");
+
+        Assert(input.Level <= State.MaximumLevelMap[input.Tick], "Already reach maximum level.");
+
+        var inscriptionInfo = GetInscriptionInfo(input.Tick);
+
+        long.TryParse(new BigIntValue(SchrodingerContractConstants.Ten).Pow(inscriptionInfo.Decimals).Value,
+            out var amount);
+
+        var logEvent = new Merged
+        {
+            Tick = input.Tick,
+            AdoptIdA = input.AdoptIdA,
+            AdoptIdB = input.AdoptIdB,
+            AmountA = ProcessAdoptId(input.AdoptIdA, inscriptionInfo.MaxGen, amount, input.Level, out var symbolA),
+            AmountB = ProcessAdoptId(input.AdoptIdB, inscriptionInfo.MaxGen, amount, input.Level, out var symbolB),
+            SymbolA = symbolA,
+            SymbolB = symbolB
+        };
+
+        GenerateAdoptInfo(inscriptionInfo, input.Tick, input.Level, amount, logEvent);
+
+        Context.Fire(logEvent);
+
+        return new Empty();
+    }
+
+    private Hash ComputeMergeInputHash(MergeInput input)
+    {
+        return HashHelper.ComputeFrom(new MergeInput
+        {
+            Tick = input.Tick,
+            AdoptIdA = input.AdoptIdA,
+            AdoptIdB = input.AdoptIdB,
+            Level = input.Level
+        }.ToByteArray());
+    }
+
+    private long ProcessAdoptId(Hash adoptId, int maxGen, long amount, long level, out string symbol)
+    {
+        var adoptInfo = State.AdoptInfoMap[adoptId];
+
+        Assert(adoptInfo != null, $"AdoptId {adoptId} not found.");
+        Assert(!adoptInfo!.IsRerolled, $"AdoptId {adoptId} already rerolled.");
+        Assert(adoptInfo.Gen == maxGen, $"AdoptId {adoptId} not reach max generation.");
+        Assert(adoptInfo.Level == 0 || adoptInfo.Level == level, "Level not matched.");
+
+        adoptInfo.Level = level;
+        symbol = adoptInfo.Symbol;
+
+        return adoptInfo.IsConfirmed ? ProcessToken(adoptInfo, amount) : ProcessAdoptInfo(adoptInfo, amount);
+    }
+
+    private long ProcessToken(AdoptInfo adoptInfo, long amount)
+    {
+        var output = State.TokenContract.GetBalance.Call(new GetBalanceInput
+        {
+            Owner = Context.Sender,
+            Symbol = adoptInfo.Symbol
+        });
+
+        State.TokenContract.TransferFrom.Send(new TransferFromInput
+        {
+            Symbol = adoptInfo.Symbol,
+            Amount = amount,
+            From = Context.Sender,
+            To = Context.Self
+        });
+
+        State.TokenContract.Burn.Send(new BurnInput
+        {
+            Symbol = adoptInfo.Symbol,
+            Amount = amount
+        });
+
+        return output.Balance.Sub(amount);
+    }
+
+    private long ProcessAdoptInfo(AdoptInfo adoptInfo, long amount)
+    {
+        Assert(adoptInfo.Adopter == Context.Sender, "No permission.");
+        Assert(adoptInfo.OutputAmount >= amount, "Not enough amount.");
+
+        adoptInfo.OutputAmount = adoptInfo.OutputAmount.Sub(amount);
+
+        return adoptInfo.OutputAmount;
+    }
+
+    private void GenerateAdoptInfo(InscriptionInfo inscriptionInfo, string tick, long level, long amount,
+        Merged logEvent)
+    {
+        var symbolCount = State.SymbolCountMap[tick];
+        var adoptId = GenerateAdoptId(tick, symbolCount);
+        Assert(State.AdoptInfoMap[adoptId] == null, "Adopt id already exists.");
+
+        var adoptInfo = new AdoptInfo
+        {
+            AdoptId = adoptId,
+            BlockHeight = Context.CurrentHeight,
+            Adopter = Context.Sender,
+            ImageCount = inscriptionInfo!.ImageCount,
+            Gen = inscriptionInfo.MaxGen
+        };
+
+        State.AdoptInfoMap[adoptId] = adoptInfo;
+
+        var mergeConfig = State.MergeConfigMap[tick];
+
+        logEvent.LossAmount = mergeConfig.PoolAmount;
+        logEvent.CommissionAmount = mergeConfig.CommissionAmount;
+
+        adoptInfo.InputAmount = amount.Mul(2);
+        adoptInfo.OutputAmount = amount;
+
+        ProcessMergeTransfer(logEvent.LossAmount, logEvent.CommissionAmount, inscriptionInfo.Recipient,
+            inscriptionInfo.Ancestor);
+
+        var randomHash = GetRandomHash(symbolCount);
+        adoptInfo.Attributes = GenerateMaxAttributes(tick, adoptInfo.Gen.Sub(1), randomHash);
+        adoptInfo.Symbol = GenerateSymbol(tick, symbolCount);
+        adoptInfo.TokenName = GenerateTokenName(adoptInfo.Symbol, adoptInfo.Gen);
+        adoptInfo.Level = GenerateLevel(tick, level, randomHash);
+
+        State.SymbolCountMap[tick] = symbolCount.Add(1);
+
+        logEvent.AdoptInfo = adoptInfo;
+    }
+
+    private void ProcessMergeTransfer(long lossAmount, long commissionAmount, Address recipient, string ancestor)
+    {
+        if (lossAmount > 0)
+        {
+            State.TokenContract.Transfer.Send(new TransferInput
+            {
+                Symbol = ancestor,
+                Amount = lossAmount,
+                To = GetReceivingAddress(GetTickFromSymbol(ancestor))
+            });
+        }
+
+        // send commission to recipient
+        if (commissionAmount > 0)
+        {
+            State.TokenContract.Transfer.Send(new TransferInput
+            {
+                Amount = commissionAmount,
+                To = recipient,
+                Symbol = ancestor
+            });
+        }
+    }
+
+    private long GenerateLevel(string tick, long level, Hash randomHash)
+    {
+        var rate = State.MergeRatesMap[tick][level];
+        var random = Context.ConvertHashToInt64(randomHash, 0, SchrodingerContractConstants.Denominator);
+
+        return random <= rate ? level.Add(1) : level;
+    }
+}

--- a/contract/Schrodinger/SchrodingerContract_Points.cs
+++ b/contract/Schrodinger/SchrodingerContract_Points.cs
@@ -166,7 +166,7 @@ public partial class SchrodingerContract
         var proportion = State.PointsProportion[actionName];
         proportion = actionName switch
         {
-            nameof(Adopt) => proportion == 0 ? SchrodingerContractConstants.DefaultAdoptProportion : proportion,
+            "Adopt" => proportion == 0 ? SchrodingerContractConstants.DefaultAdoptProportion : proportion,
             nameof(Reroll) => proportion == 0 ? SchrodingerContractConstants.DefaultRerollProportion : proportion,
             nameof(AdoptMaxGen) => proportion == 0 ? SchrodingerContractConstants.DefaultAdoptMaxGenProportion : proportion,
             _ => proportion == 0 ? SchrodingerContractConstants.DefaultProportion : proportion

--- a/contract/Schrodinger/SchrodingerContract_View.cs
+++ b/contract/Schrodinger/SchrodingerContract_View.cs
@@ -191,4 +191,51 @@ public partial class SchrodingerContract
     {
         return State.AirdropControllerMap[input.Value];
     }
+
+    public override RerollConfig GetRerollConfig(StringValue input)
+    {
+        return input != null && IsStringValid(input.Value) ? State.RerollConfigMap[input.Value] : new RerollConfig();
+    }
+
+    public override GetMergeConfigOutput GetMergeConfig(StringValue input)
+    {
+        if (input == null || !IsStringValid(input.Value)) return new GetMergeConfigOutput();
+
+        var output = new GetMergeConfigOutput
+        {
+            Tick = input.Value,
+            MaximumLevel = State.MaximumLevelMap[input.Value],
+            Config = State.MergeConfigMap[input.Value]
+        };
+        
+        var mergeRates = new MergeRates();
+
+        for (var i = 1; i <= output.MaximumLevel; i++)
+        {
+            mergeRates.Data.Add(new MergeRate
+            {
+                Level = i,
+                Rate = State.MergeRatesMap[output.Tick][i]
+            });
+        }
+
+        output.MergeRates = mergeRates;
+        
+        return output;
+    }
+
+    public override VoucherAdoptionConfig GetVoucherAdoptionConfig(StringValue input)
+    {
+        return input != null && IsStringValid(input.Value)
+            ? State.VoucherAdoptionConfigMap[input.Value]
+            : new VoucherAdoptionConfig();
+    }
+
+    public override Int64Value GetSymbolCount(StringValue input)
+    {
+        return new Int64Value
+        {
+            Value = State.SymbolCountMap[input.Value]
+        };
+    }
 }

--- a/protobuf/schrodinger_contract.proto
+++ b/protobuf/schrodinger_contract.proto
@@ -15,12 +15,12 @@ service SchrodingerContract {
   // core
   rpc Initialize(InitializeInput) returns (google.protobuf.Empty) {}
   rpc Deploy (DeployInput) returns (google.protobuf.Empty) {}
-  rpc Adopt (AdoptInput) returns (google.protobuf.Empty) {}
+//  rpc Adopt (AdoptInput) returns (google.protobuf.Empty) {}
   rpc Confirm (ConfirmInput) returns (google.protobuf.Empty) {}
   rpc Reroll (RerollInput) returns (google.protobuf.Empty) {}
   rpc AdoptMaxGen (AdoptMaxGenInput) returns (google.protobuf.Empty) {}
   rpc RerollAdoption (aelf.Hash) returns (google.protobuf.Empty) {}
-  rpc UpdateAdoption (aelf.Hash) returns (google.protobuf.Empty) {}
+//  rpc UpdateAdoption (aelf.Hash) returns (google.protobuf.Empty) {}
 
   // token
   rpc SetFixedAttribute (SetAttributeInput) returns (google.protobuf.Empty) {}
@@ -41,6 +41,7 @@ service SchrodingerContract {
   rpc GetAttributeValues (GetAttributeValuesInput) returns (AttributeInfos) {option (aelf.is_view) = true;}
   rpc GetAdoptInfo (aelf.Hash) returns (AdoptInfo) {option (aelf.is_view) = true;}
   rpc GetTokenInfo (google.protobuf.StringValue) returns (GetTokenInfoOutput) {option (aelf.is_view) = true;}
+  rpc GetSymbolCount (google.protobuf.StringValue) returns (google.protobuf.Int64Value) {option (aelf.is_view) = true;}
 
   // contract
   rpc SetConfig (Config) returns (google.protobuf.Empty) {}
@@ -192,6 +193,7 @@ message AdoptInfo {
   bool is_confirmed = 14;
   bool is_rerolled = 15;
   bool is_updated = 16;
+  int64 level = 17;
 }
 
 message Attributes {

--- a/protobuf/schrodinger_contract_impl.proto
+++ b/protobuf/schrodinger_contract_impl.proto
@@ -24,12 +24,24 @@ service SchrodingerContractImpl {
   rpc GetVoucherInfo (aelf.Hash) returns (VoucherInfo) {option (aelf.is_view) = true;}
   rpc ConfirmVoucher (ConfirmVoucherInput) returns (google.protobuf.Empty) {}
   rpc GetAdoptionVoucherAmount (GetAdoptionVoucherAmountInput) returns (google.protobuf.Int64Value) {option (aelf.is_view) = true;}
-  
+  rpc SetVoucherAdoptionConfig (SetVoucherAdoptionConfigInput) returns (google.protobuf.Empty) {}
+  rpc GetVoucherAdoptionConfig (google.protobuf.StringValue) returns (VoucherAdoptionConfig) {option (aelf.is_view) = true;}
+
   // airdrop
   rpc AirdropVoucher (AirdropVoucherInput) returns (google.protobuf.Empty) {}
   rpc GetAirdropController (google.protobuf.StringValue) returns (AddressList) {option (aelf.is_view) = true;}
   rpc AddAirdropController (AddAirdropControllerInput) returns (google.protobuf.Empty) {}
   rpc RemoveAirdropController (RemoveAirdropControllerInput) returns (google.protobuf.Empty) {}
+  
+  // reroll
+  rpc SetRerollConfig (SetRerollConfigInput) returns (google.protobuf.Empty) {}
+  rpc GetRerollConfig (google.protobuf.StringValue) returns (RerollConfig) {option (aelf.is_view) = true;}
+  
+  // merge
+  rpc SetMergeConfig (SetMergeConfigInput) returns (google.protobuf.Empty) {}
+  rpc GetMergeConfig (google.protobuf.StringValue) returns (GetMergeConfigOutput) {option (aelf.is_view) = true;}
+  rpc SetMergeRatesConfig (SetMergeRatesConfigInput) returns (google.protobuf.Empty) {}
+  rpc Merge (MergeInput) returns (google.protobuf.Empty) {}
 }
 
 message SetRewardConfigInput {
@@ -97,6 +109,17 @@ message GetAdoptionVoucherAmountInput {
   aelf.Address account = 2;
 }
 
+message SetVoucherAdoptionConfigInput {
+  string tick = 1;
+  int64 commission_amount = 2;
+  int64 pool_amount = 3;
+}
+
+message VoucherAdoptionConfig {
+  int64 commission_amount = 1;
+  int64 pool_amount = 2;
+}
+
 message AirdropVoucherInput {
   string tick = 1;
   repeated aelf.Address list = 2;
@@ -115,6 +138,58 @@ message AddAirdropControllerInput {
 message RemoveAirdropControllerInput {
   string tick = 1;
   repeated aelf.Address list = 2;
+}
+
+message RerollConfig {
+  int64 rate = 1;
+  int64 index = 2;
+}
+
+message SetRerollConfigInput {
+  string tick = 1;
+  int64 rate = 2;
+  int64 index = 3;
+}
+
+message MergeRates {
+  repeated MergeRate data = 1;
+}
+
+message MergeRate {
+  int64 level = 1;
+  int64 rate = 2;
+}
+
+message SetMergeRatesConfigInput {
+  string tick = 1;
+  repeated MergeRate merge_rates = 2;
+  int64 maximum_level = 3;
+}
+
+message SetMergeConfigInput {
+  string tick = 1;
+  int64 commission_amount = 2;
+  int64 pool_amount = 3;
+}
+
+message MergeConfig {
+  int64 commission_amount = 1;
+  int64 pool_amount = 2;
+}
+
+message GetMergeConfigOutput {
+  string tick = 1;
+  MergeConfig config = 2;
+  MergeRates merge_rates = 3;
+  int64 maximum_level = 4;
+}
+
+message MergeInput {
+  string tick = 1;
+  aelf.Hash adopt_id_a = 2;
+  aelf.Hash adopt_id_b = 3;
+  int64 level = 4;
+  bytes signature = 10000;
 }
 
 // log event
@@ -159,4 +234,43 @@ message AirdropControllerRemoved {
   option (aelf.is_event) = true;
   string tick = 1;
   AddressList addresses = 2;
+}
+
+message RerollConfigSet {
+  option (aelf.is_event) = true;
+  string tick = 1;
+  RerollConfig config = 2;
+}
+
+message MergeRatesConfigSet {
+  option (aelf.is_event) = true;
+  string tick = 1;
+  MergeRates merge_rates = 2;
+  int64 maximum_level = 3;
+}
+
+message MergeConfigSet {
+  option (aelf.is_event) = true;
+  string tick = 1;
+  MergeConfig config = 2;
+}
+
+message Merged {
+  option (aelf.is_event) = true;
+  string tick = 1;
+  aelf.Hash adopt_id_a = 2;
+  aelf.Hash adopt_id_b = 3;
+  string symbol_a = 4;
+  string symbol_b = 5;
+  int64 amount_a = 6;
+  int64 amount_b = 7;
+  AdoptInfo adopt_info = 8;
+  int64 loss_amount = 9;
+  int64 commission_amount = 10;
+}
+
+message VoucherAdoptionConfigSet {
+  option (aelf.is_event) = true;
+  string tick = 1;
+  VoucherAdoptionConfig config = 2;
 }

--- a/test/Schrodinger.Contracts.Tests/SchrodingerContractTests_Adopt.cs
+++ b/test/Schrodinger.Contracts.Tests/SchrodingerContractTests_Adopt.cs
@@ -12,158 +12,158 @@ public partial class SchrodingerContractTests
 {
     private const string Gen0 = "SGR-1";
 
-    [Fact]
-    public async Task AdoptTests()
-    {
-        Hash adoptId;
-        string symbol;
-        long amount;
-
-        await DeployTest();
-        // await SetPointsProportion();
-
-        {
-            var balance = await GetTokenBalance(Gen0, DefaultAddress);
-            balance.ShouldBe(0);
-        }
-
-        await TokenContractStub.Issue.SendAsync(new IssueInput
-        {
-            Symbol = Gen0,
-            Amount = 2_00000000,
-            To = DefaultAddress
-        });
-
-        {
-            var balance = await GetTokenBalance(Gen0, DefaultAddress);
-            balance.ShouldBe(2_00000000);
-        }
-
-        await TokenContractStub.Approve.SendAsync(new ApproveInput
-        {
-            Symbol = Gen0,
-            Amount = 2_00000000,
-            Spender = SchrodingerContractAddress
-        });
-
-        {
-            var result = await SchrodingerContractStub.Adopt.SendAsync(new AdoptInput
-            {
-                Parent = Gen0,
-                Amount = 2_00000000,
-                Domain = "test"
-            });
-
-            var log = GetLogEvent<Adopted>(result.TransactionResult);
-            log.Ancestor.ShouldBe(Gen0);
-            log.Adopter.ShouldBe(DefaultAddress);
-            log.InputAmount.ShouldBe(2_00000000);
-            log.OutputAmount.ShouldBe(1_90000000);
-            log.LossAmount.ShouldBe(9000000);
-            log.CommissionAmount.ShouldBe(1000000);
-
-            adoptId = log.AdoptId;
-            symbol = log.Symbol;
-
-            var receivingAddress = await SchrodingerContractStub.GetReceivingAddress.CallAsync(new StringValue
-            {
-                Value = _tick
-            });
-
-            GetTokenBalance(Gen0, receivingAddress).Result.ShouldBe(log.LossAmount);
-        }
-
-        {
-            var confirmInput = new ConfirmInput
-            {
-                AdoptId = adoptId,
-                Image = "test",
-                ImageUri = "test"
-            };
-
-            confirmInput.Signature = GenerateSignature(DefaultKeyPair.PrivateKey, confirmInput.AdoptId,
-                confirmInput.Image, confirmInput.ImageUri);
-
-            var result = await SchrodingerContractStub.Confirm.SendAsync(confirmInput);
-
-            var log = GetLogEvent<Confirmed>(result.TransactionResult);
-        }
-
-        {
-            var balance = await GetTokenBalance(Gen0, DefaultAddress);
-            balance.ShouldBe(1000000);
-        }
-        {
-            var balance = await GetTokenBalance(symbol, DefaultAddress);
-            balance.ShouldBe(1_90000000);
-        }
-
-        {
-            await TokenContractStub.Approve.SendAsync(new ApproveInput
-            {
-                Spender = SchrodingerContractAddress,
-                Symbol = symbol,
-                Amount = 1_90000000
-            });
-
-            var result = await SchrodingerContractStub.Adopt.SendAsync(new AdoptInput
-            {
-                Parent = symbol,
-                Amount = 1_90000000,
-                Domain = "test"
-            });
-
-            var log = GetLogEvent<Adopted>(result.TransactionResult);
-
-            adoptId = log.AdoptId;
-            symbol = log.Symbol;
-            amount = log.OutputAmount;
-        }
-
-        {
-            var confirmInput = new ConfirmInput
-            {
-                AdoptId = adoptId,
-                Image = "test",
-                ImageUri = "test"
-            };
-
-            confirmInput.Signature = GenerateSignature(DefaultKeyPair.PrivateKey, confirmInput.AdoptId,
-                confirmInput.Image, confirmInput.ImageUri);
-
-            var result = await SchrodingerContractStub.Confirm.SendAsync(confirmInput);
-
-            var log = GetLogEvent<Confirmed>(result.TransactionResult);
-        }
-
-        {
-            await TokenContractStub.Approve.SendAsync(new ApproveInput
-            {
-                Spender = SchrodingerContractAddress,
-                Symbol = symbol,
-                Amount = amount
-            });
-
-            var result = await SchrodingerContractStub.Reroll.SendAsync(new RerollInput
-            {
-                Symbol = symbol,
-                Amount = amount,
-                Domain = "test"
-            });
-
-            var log = GetLogEvent<Rerolled>(result.TransactionResult);
-        }
-
-        {
-            var balance = await GetTokenBalance(symbol, DefaultAddress);
-            balance.ShouldBe(0);
-        }
-    }
+    // [Fact]
+    // public async Task AdoptTests()
+    // {
+    //     Hash adoptId;
+    //     string symbol;
+    //     long amount;
+    //
+    //     await DeployTest();
+    //     // await SetPointsProportion();
+    //
+    //     {
+    //         var balance = await GetTokenBalance(Gen0, DefaultAddress);
+    //         balance.ShouldBe(0);
+    //     }
+    //
+    //     await TokenContractStub.Issue.SendAsync(new IssueInput
+    //     {
+    //         Symbol = Gen0,
+    //         Amount = 2_00000000,
+    //         To = DefaultAddress
+    //     });
+    //
+    //     {
+    //         var balance = await GetTokenBalance(Gen0, DefaultAddress);
+    //         balance.ShouldBe(2_00000000);
+    //     }
+    //
+    //     await TokenContractStub.Approve.SendAsync(new ApproveInput
+    //     {
+    //         Symbol = Gen0,
+    //         Amount = 2_00000000,
+    //         Spender = SchrodingerContractAddress
+    //     });
+    //
+    //     {
+    //         var result = await SchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+    //         {
+    //             Parent = Gen0,
+    //             Amount = 2_00000000,
+    //             Domain = "test"
+    //         });
+    //
+    //         var log = GetLogEvent<Adopted>(result.TransactionResult);
+    //         log.Ancestor.ShouldBe(Gen0);
+    //         log.Adopter.ShouldBe(DefaultAddress);
+    //         log.InputAmount.ShouldBe(2_00000000);
+    //         log.OutputAmount.ShouldBe(1_90000000);
+    //         log.LossAmount.ShouldBe(9000000);
+    //         log.CommissionAmount.ShouldBe(1000000);
+    //
+    //         adoptId = log.AdoptId;
+    //         symbol = log.Symbol;
+    //
+    //         var receivingAddress = await SchrodingerContractStub.GetReceivingAddress.CallAsync(new StringValue
+    //         {
+    //             Value = _tick
+    //         });
+    //
+    //         GetTokenBalance(Gen0, receivingAddress).Result.ShouldBe(log.LossAmount);
+    //     }
+    //
+    //     {
+    //         var confirmInput = new ConfirmInput
+    //         {
+    //             AdoptId = adoptId,
+    //             Image = "test",
+    //             ImageUri = "test"
+    //         };
+    //
+    //         confirmInput.Signature = GenerateSignature(DefaultKeyPair.PrivateKey, confirmInput.AdoptId,
+    //             confirmInput.Image, confirmInput.ImageUri);
+    //
+    //         var result = await SchrodingerContractStub.Confirm.SendAsync(confirmInput);
+    //
+    //         var log = GetLogEvent<Confirmed>(result.TransactionResult);
+    //     }
+    //
+    //     {
+    //         var balance = await GetTokenBalance(Gen0, DefaultAddress);
+    //         balance.ShouldBe(1000000);
+    //     }
+    //     {
+    //         var balance = await GetTokenBalance(symbol, DefaultAddress);
+    //         balance.ShouldBe(1_90000000);
+    //     }
+    //
+    //     {
+    //         await TokenContractStub.Approve.SendAsync(new ApproveInput
+    //         {
+    //             Spender = SchrodingerContractAddress,
+    //             Symbol = symbol,
+    //             Amount = 1_90000000
+    //         });
+    //
+    //         var result = await SchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+    //         {
+    //             Parent = symbol,
+    //             Amount = 1_90000000,
+    //             Domain = "test"
+    //         });
+    //
+    //         var log = GetLogEvent<Adopted>(result.TransactionResult);
+    //
+    //         adoptId = log.AdoptId;
+    //         symbol = log.Symbol;
+    //         amount = log.OutputAmount;
+    //     }
+    //
+    //     {
+    //         var confirmInput = new ConfirmInput
+    //         {
+    //             AdoptId = adoptId,
+    //             Image = "test",
+    //             ImageUri = "test"
+    //         };
+    //
+    //         confirmInput.Signature = GenerateSignature(DefaultKeyPair.PrivateKey, confirmInput.AdoptId,
+    //             confirmInput.Image, confirmInput.ImageUri);
+    //
+    //         var result = await SchrodingerContractStub.Confirm.SendAsync(confirmInput);
+    //
+    //         var log = GetLogEvent<Confirmed>(result.TransactionResult);
+    //     }
+    //
+    //     {
+    //         await TokenContractStub.Approve.SendAsync(new ApproveInput
+    //         {
+    //             Spender = SchrodingerContractAddress,
+    //             Symbol = symbol,
+    //             Amount = amount
+    //         });
+    //
+    //         var result = await SchrodingerContractStub.Reroll.SendAsync(new RerollInput
+    //         {
+    //             Symbol = symbol,
+    //             Amount = amount,
+    //             Domain = "test"
+    //         });
+    //
+    //         var log = GetLogEvent<Rerolled>(result.TransactionResult);
+    //     }
+    //
+    //     {
+    //         var balance = await GetTokenBalance(symbol, DefaultAddress);
+    //         balance.ShouldBe(0);
+    //     }
+    // }
 
     [Fact]
     public async Task TransferFromReceivingAddressTests()
     {
-        await AdoptTests();
+        await Adopt();
 
         GetTokenBalance(Gen0, User2Address).Result.ShouldBe(0);
 
@@ -257,6 +257,9 @@ public partial class SchrodingerContractTests
             Domain = "test"
         });
         result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
+
+        var output = await SchrodingerContractStub.GetSymbolCount.CallAsync(new StringValue { Value = _tick });
+        output.Value.ShouldBe(4);
     }
 
     [Fact]
@@ -307,7 +310,7 @@ public partial class SchrodingerContractTests
             Amount = 1,
             Domain = "test"
         });
-        result.TransactionResult.Error.ShouldContain("Tick not deployed.");
+        result.TransactionResult.Error.ShouldContain("Inscription not found.");
 
         result = await SchrodingerContractStub.AdoptMaxGen.SendWithExceptionAsync(new AdoptMaxGenInput
         {
@@ -340,9 +343,9 @@ public partial class SchrodingerContractTests
         var balance = await GetTokenBalance(Gen0, UserAddress);
         balance.ShouldBe(2_00000000);
 
-        var result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+        var result = await UserSchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
         {
-            Parent = Gen0,
+            Tick = _tick,
             Amount = 2_00000000,
             Domain = "test"
         });
@@ -388,9 +391,9 @@ public partial class SchrodingerContractTests
             Spender = SchrodingerContractAddress
         });
 
-        var result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+        var result = await UserSchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
         {
-            Parent = Gen0,
+            Tick = _tick,
             Amount = 2_00000000,
             Domain = "test"
         });
@@ -417,9 +420,9 @@ public partial class SchrodingerContractTests
         result = await UserSchrodingerContractStub.RerollAdoption.SendWithExceptionAsync(adoptId);
         result.TransactionResult.Error.ShouldContain("Already confirmed.");
 
-        result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+        result = await UserSchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
         {
-            Parent = Gen0,
+            Tick = _tick,
             Amount = 2_00000000,
             Domain = "test"
         });
@@ -430,9 +433,9 @@ public partial class SchrodingerContractTests
         result = await UserSchrodingerContractStub.RerollAdoption.SendWithExceptionAsync(adoptId);
         result.TransactionResult.Error.ShouldContain("Already rerolled.");
 
-        result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+        result = await UserSchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
         {
-            Parent = Gen0,
+            Tick = _tick,
             Amount = 2_00000000,
             Domain = "test"
         });
@@ -450,88 +453,155 @@ public partial class SchrodingerContractTests
         result.TransactionResult.Error.ShouldContain("Already rerolled.");
     }
 
-    [Fact]
-    public async Task UpdateAdoptionTests()
-    {
-        var adoptId = await Adopt();
-        var adoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(adoptId);
-        adoptInfo.IsUpdated.ShouldBeFalse();
+    // [Fact]
+    // public async Task UpdateAdoptionTests()
+    // {
+    //     var adoptId = await Adopt();
+    //     var adoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(adoptId);
+    //     adoptInfo.IsUpdated.ShouldBeFalse();
+    //
+    //     var result = await SchrodingerContractStub.UpdateAdoption.SendAsync(adoptId);
+    //     result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
+    //
+    //     var log = GetLogEvent<AdoptionUpdated>(result.TransactionResult);
+    //     log.Parent.ShouldBe(adoptInfo.Symbol);
+    //     log.ParentGen.ShouldBe(adoptInfo.Gen);
+    //     log.InputAmount.ShouldBe(adoptInfo.OutputAmount);
+    //     log.LossAmount.ShouldBe(adoptInfo.OutputAmount * 5 / 100 * 90 / 100);
+    //     log.OutputAmount.ShouldBe(adoptInfo.OutputAmount * 95 / 100);
+    //     log.ImageCount.ShouldBe(adoptInfo.ImageCount);
+    //     log.Adopter.ShouldBe(adoptInfo.Adopter);
+    //     log.BlockHeight.ShouldBe(result.TransactionResult.BlockNumber);
+    //     log.Attributes.Data.Count.ShouldBe(adoptInfo.Attributes.Data.Count + 2);
+    //     log.Gen.ShouldBe(adoptInfo.Gen + 2);
+    //     log.Ancestor.ShouldBe(Gen0);
+    //     log.Symbol.ShouldBe("SGR-3");
+    //     log.TokenName.ShouldBe("SGR-3GEN4");
+    //
+    //     var newAdoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(log.AdoptId);
+    //     newAdoptInfo.AdoptId.ShouldBe(log.AdoptId);
+    //     newAdoptInfo.Parent.ShouldBe(log.Parent);
+    //     newAdoptInfo.ParentGen.ShouldBe(log.ParentGen);
+    //     newAdoptInfo.InputAmount.ShouldBe(log.InputAmount);
+    //     newAdoptInfo.OutputAmount.ShouldBe(log.OutputAmount);
+    //     newAdoptInfo.ParentAttributes.ShouldBe(adoptInfo.Attributes);
+    //     newAdoptInfo.Attributes.ShouldBe(log.Attributes);
+    //     newAdoptInfo.ImageCount.ShouldBe(log.ImageCount);
+    //     newAdoptInfo.BlockHeight.ShouldBe(log.BlockHeight);
+    //     newAdoptInfo.Symbol.ShouldBe(log.Symbol);
+    //     newAdoptInfo.TokenName.ShouldBe(log.TokenName);
+    //     newAdoptInfo.Gen.ShouldBe(log.Gen);
+    //     newAdoptInfo.Adopter.ShouldBe(log.Adopter);
+    //     newAdoptInfo.IsUpdated.ShouldBeFalse();
+    //
+    //     adoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(adoptId);
+    //     adoptInfo.IsUpdated.ShouldBeTrue();
+    // }
+    //
+    // [Fact]
+    // public async Task UpdateAdoptionTests_Fail()
+    // {
+    //     await DeployForMaxGen();
+    //
+    //     await TokenContractStub.Issue.SendAsync(new IssueInput
+    //     {
+    //         Symbol = Gen0,
+    //         Amount = 6_00000000,
+    //         To = UserAddress
+    //     });
+    //
+    //     await TokenContractUserStub.Approve.SendAsync(new ApproveInput
+    //     {
+    //         Symbol = Gen0,
+    //         Amount = 6_00000000,
+    //         Spender = SchrodingerContractAddress
+    //     });
+    //
+    //     var result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+    //     {
+    //         Parent = Gen0,
+    //         Amount = 2_00000000,
+    //         Domain = "test"
+    //     });
+    //     var adoptId = GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
+    //
+    //     result = await UserSchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(new Hash());
+    //     result.TransactionResult.Error.ShouldContain("Invalid input.");
+    //
+    //     result = await UserSchrodingerContractStub.UpdateAdoption
+    //         .SendWithExceptionAsync(HashHelper.ComputeFrom("test"));
+    //     result.TransactionResult.Error.ShouldContain("Adopt id not exists.");
+    //
+    //     result = await SchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(adoptId);
+    //     result.TransactionResult.Error.ShouldContain("No permission.");
+    //
+    //     await UserSchrodingerContractStub.Confirm.SendAsync(new ConfirmInput
+    //     {
+    //         AdoptId = adoptId,
+    //         Image = "image",
+    //         ImageUri = "uri",
+    //         Signature = GenerateSignature(DefaultKeyPair.PrivateKey, adoptId, "image", "uri")
+    //     });
+    //
+    //     result = await UserSchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(adoptId);
+    //     result.TransactionResult.Error.ShouldContain("Already confirmed.");
+    //
+    //     result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+    //     {
+    //         Parent = Gen0,
+    //         Amount = 2_00000000,
+    //         Domain = "test"
+    //     });
+    //     adoptId = GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
+    //
+    //     await UserSchrodingerContractStub.RerollAdoption.SendAsync(adoptId);
+    //
+    //     result = await UserSchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(adoptId);
+    //     result.TransactionResult.Error.ShouldContain("Already rerolled.");
+    //
+    //     result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+    //     {
+    //         Parent = Gen0,
+    //         Amount = 2_00000000,
+    //         Domain = "test"
+    //     });
+    //     adoptId = GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
+    //
+    //     await UserSchrodingerContractStub.UpdateAdoption.SendAsync(adoptId);
+    //
+    //     result = await UserSchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(adoptId);
+    //     result.TransactionResult.Error.ShouldContain("Already updated.");
+    // }
 
-        var result = await SchrodingerContractStub.UpdateAdoption.SendAsync(adoptId);
-        result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
-        
-        var log = GetLogEvent<AdoptionUpdated>(result.TransactionResult);
-        log.Parent.ShouldBe(adoptInfo.Symbol);
-        log.ParentGen.ShouldBe(adoptInfo.Gen);
-        log.InputAmount.ShouldBe(adoptInfo.OutputAmount);
-        log.LossAmount.ShouldBe(adoptInfo.OutputAmount * 5 / 100 * 90 / 100);
-        log.OutputAmount.ShouldBe(adoptInfo.OutputAmount * 95 / 100);
-        log.ImageCount.ShouldBe(adoptInfo.ImageCount);
-        log.Adopter.ShouldBe(adoptInfo.Adopter);
-        log.BlockHeight.ShouldBe(result.TransactionResult.BlockNumber);
-        log.Attributes.Data.Count.ShouldBe(adoptInfo.Attributes.Data.Count + 2);
-        log.Gen.ShouldBe(adoptInfo.Gen + 2);
-        log.Ancestor.ShouldBe(Gen0);
-        log.Symbol.ShouldBe("SGR-3");
-        log.TokenName.ShouldBe("SGR-3GEN4");
-
-        var newAdoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(log.AdoptId);
-        newAdoptInfo.AdoptId.ShouldBe(log.AdoptId);
-        newAdoptInfo.Parent.ShouldBe(log.Parent);
-        newAdoptInfo.ParentGen.ShouldBe(log.ParentGen);
-        newAdoptInfo.InputAmount.ShouldBe(log.InputAmount);
-        newAdoptInfo.OutputAmount.ShouldBe(log.OutputAmount);
-        newAdoptInfo.ParentAttributes.ShouldBe(adoptInfo.Attributes);
-        newAdoptInfo.Attributes.ShouldBe(log.Attributes);
-        newAdoptInfo.ImageCount.ShouldBe(log.ImageCount);
-        newAdoptInfo.BlockHeight.ShouldBe(log.BlockHeight);
-        newAdoptInfo.Symbol.ShouldBe(log.Symbol);
-        newAdoptInfo.TokenName.ShouldBe(log.TokenName);
-        newAdoptInfo.Gen.ShouldBe(log.Gen);
-        newAdoptInfo.Adopter.ShouldBe(log.Adopter);
-        newAdoptInfo.IsUpdated.ShouldBeFalse();
-        
-        adoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(adoptId);
-        adoptInfo.IsUpdated.ShouldBeTrue();
-    }
-    
     [Fact]
-    public async Task UpdateAdoptionTests_Fail()
+    public async Task RerollTests_WithRerollConfig()
     {
         await DeployForMaxGen();
 
         await TokenContractStub.Issue.SendAsync(new IssueInput
         {
             Symbol = Gen0,
-            Amount = 6_00000000,
+            Amount = 4_00000000,
             To = UserAddress
         });
+
+        var balance = await GetTokenBalance($"{_tick}-1", UserAddress);
+        balance.ShouldBe(4_00000000);
 
         await TokenContractUserStub.Approve.SendAsync(new ApproveInput
         {
             Symbol = Gen0,
-            Amount = 6_00000000,
+            Amount = 4_00000000,
             Spender = SchrodingerContractAddress
         });
 
-        var result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+        var result = await UserSchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
         {
-            Parent = Gen0,
             Amount = 2_00000000,
-            Domain = "test"
+            Domain = "test",
+            Tick = _tick
         });
         var adoptId = GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
-
-        result = await UserSchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(new Hash());
-        result.TransactionResult.Error.ShouldContain("Invalid input.");
-
-        result = await UserSchrodingerContractStub.UpdateAdoption
-            .SendWithExceptionAsync(HashHelper.ComputeFrom("test"));
-        result.TransactionResult.Error.ShouldContain("Adopt id not exists.");
-
-        result = await SchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(adoptId);
-        result.TransactionResult.Error.ShouldContain("No permission.");
-
         await UserSchrodingerContractStub.Confirm.SendAsync(new ConfirmInput
         {
             AdoptId = adoptId,
@@ -540,47 +610,143 @@ public partial class SchrodingerContractTests
             Signature = GenerateSignature(DefaultKeyPair.PrivateKey, adoptId, "image", "uri")
         });
 
-        result = await UserSchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(adoptId);
-        result.TransactionResult.Error.ShouldContain("Already confirmed.");
-
-        result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+        result = await UserSchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
         {
-            Parent = Gen0,
             Amount = 2_00000000,
+            Domain = "test",
+            Tick = _tick
+        });
+        var adoptId2 = GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
+
+        await UserSchrodingerContractStub.Confirm.SendAsync(new ConfirmInput
+        {
+            AdoptId = adoptId2,
+            Image = "image",
+            ImageUri = "uri",
+            Signature = GenerateSignature(DefaultKeyPair.PrivateKey, adoptId2, "image", "uri")
+        });
+
+        balance = await GetTokenBalance($"{_tick}-1", UserAddress);
+        balance.ShouldBe(0);
+
+        balance = await GetTokenBalance($"{_tick}-2", UserAddress);
+        balance.ShouldBe(1_00000000);
+
+        balance = await GetTokenBalance($"{_tick}-3", UserAddress);
+        balance.ShouldBe(1_00000000);
+
+        await TokenContractUserStub.Approve.SendAsync(new ApproveInput
+        {
+            Symbol = $"{_tick}-2",
+            Spender = SchrodingerContractAddress,
+            Amount = 1_00000000
+        });
+
+        await TokenContractUserStub.Approve.SendAsync(new ApproveInput
+        {
+            Symbol = $"{_tick}-3",
+            Spender = SchrodingerContractAddress,
+            Amount = 1_00000000
+        });
+
+        await SchrodingerContractStub.SetRerollConfig.SendAsync(new SetRerollConfigInput
+        {
+            Tick = _tick,
+            Index = 3,
+            Rate = 5000
+        });
+
+        await UserSchrodingerContractStub.Reroll.SendAsync(new RerollInput
+        {
+            Amount = 1_00000000,
+            Symbol = $"{_tick}-2",
             Domain = "test"
         });
-        adoptId = GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
+
+        balance = await GetTokenBalance($"{_tick}-1", UserAddress);
+        balance.ShouldBe(1_00000000);
+
+        await UserSchrodingerContractStub.Reroll.SendAsync(new RerollInput
+        {
+            Amount = 1_00000000,
+            Symbol = $"{_tick}-3",
+            Domain = "test"
+        });
+
+        balance = await GetTokenBalance($"{_tick}-1", UserAddress);
+        balance.ShouldBe(1_50000000);
+    }
+
+    [Fact]
+    public async Task RerollAdoptionTests_WithRerollConfig()
+    {
+        await DeployForMaxGen();
+
+        await TokenContractStub.Issue.SendAsync(new IssueInput
+        {
+            Symbol = Gen0,
+            Amount = 4_00000000,
+            To = UserAddress
+        });
+
+        var balance = await GetTokenBalance($"{_tick}-1", UserAddress);
+        balance.ShouldBe(4_00000000);
+
+        await TokenContractUserStub.Approve.SendAsync(new ApproveInput
+        {
+            Symbol = Gen0,
+            Amount = 4_00000000,
+            Spender = SchrodingerContractAddress
+        });
+
+        var result = await UserSchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
+        {
+            Amount = 2_00000000,
+            Domain = "test",
+            Tick = _tick
+        });
+        var adoptId = GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
+
+        result = await UserSchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
+        {
+            Amount = 2_00000000,
+            Domain = "test",
+            Tick = _tick
+        });
+        var adoptId2 = GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
+
+        balance = await GetTokenBalance($"{_tick}-1", UserAddress);
+        balance.ShouldBe(0);
+
+        await SchrodingerContractStub.SetRerollConfig.SendAsync(new SetRerollConfigInput
+        {
+            Tick = _tick,
+            Index = 3,
+            Rate = 5000
+        });
 
         await UserSchrodingerContractStub.RerollAdoption.SendAsync(adoptId);
 
-        result = await UserSchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(adoptId);
-        result.TransactionResult.Error.ShouldContain("Already rerolled.");
+        balance = await GetTokenBalance($"{_tick}-1", UserAddress);
+        balance.ShouldBe(1_00000000);
 
-        result = await UserSchrodingerContractStub.Adopt.SendAsync(new AdoptInput
-        {
-            Parent = Gen0,
-            Amount = 2_00000000,
-            Domain = "test"
-        });
-        adoptId = GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
+        await UserSchrodingerContractStub.RerollAdoption.SendAsync(adoptId2);
 
-        await UserSchrodingerContractStub.UpdateAdoption.SendAsync(adoptId);
-
-        result = await UserSchrodingerContractStub.UpdateAdoption.SendWithExceptionAsync(adoptId);
-        result.TransactionResult.Error.ShouldContain("Already updated.");
+        balance = await GetTokenBalance($"{_tick}-1", UserAddress);
+        balance.ShouldBe(1_50000000);
     }
 
     private async Task DeployForMaxGen()
     {
         await DeployCollectionTest();
         await Initialize();
-        await SchrodingerContractStub.Deploy.SendAsync(new DeployInput()
+        await SchrodingerContractStub.Deploy.SendAsync(new DeployInput
         {
             Tick = _tick,
             AttributesPerGen = 1,
             MaxGeneration = 9,
             ImageCount = 2,
-            Decimals = 0,
+            Decimals = 8,
             CommissionRate = 1000,
             LossRate = 500,
             AttributeLists = GetAttributeListsForMaxGen(),
@@ -659,9 +825,9 @@ public partial class SchrodingerContractTests
             Spender = SchrodingerContractAddress
         });
 
-        var result = await SchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+        var result = await SchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
         {
-            Parent = Gen0,
+            Tick = _tick,
             Amount = 2_00000000,
             Domain = "test"
         });

--- a/test/Schrodinger.Contracts.Tests/SchrodingerContractTests_Airdrop.cs
+++ b/test/Schrodinger.Contracts.Tests/SchrodingerContractTests_Airdrop.cs
@@ -210,7 +210,7 @@ public partial class SchrodingerContractTests
             List = { new Address() },
             Amount = 1
         });
-        result.TransactionResult.Error.ShouldContain("Tick not deployed.");
+        result.TransactionResult.Error.ShouldContain("Inscription not found.");
 
         result = await UserSchrodingerContractStub.AirdropVoucher.SendWithExceptionAsync(new AirdropVoucherInput
         {

--- a/test/Schrodinger.Contracts.Tests/SchrodingerContractTests_Merge.cs
+++ b/test/Schrodinger.Contracts.Tests/SchrodingerContractTests_Merge.cs
@@ -1,0 +1,673 @@
+using System.Linq;
+using System.Threading.Tasks;
+using AElf;
+using AElf.Contracts.MultiToken;
+using AElf.Cryptography;
+using AElf.Types;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Shouldly;
+using Xunit;
+
+namespace Schrodinger;
+
+public partial class SchrodingerContractTests
+{
+    [Fact]
+    public async Task SetMergeRatesConfigTests()
+    {
+        await DeployTest();
+
+        var result = await SchrodingerContractStub.SetMergeRatesConfig.SendAsync(new SetMergeRatesConfigInput
+        {
+            Tick = _tick,
+            MaximumLevel = 2,
+            MergeRates =
+            {
+                new MergeRate
+                {
+                    Level = 1,
+                    Rate = 5
+                },
+                new MergeRate
+                {
+                    Level = 2,
+                    Rate = 5
+                },
+                new MergeRate
+                {
+                    Level = 3,
+                    Rate = 5
+                }
+            }
+        });
+
+        result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
+
+        var log = GetLogEvent<MergeRatesConfigSet>(result.TransactionResult);
+        log.MergeRates.Data.Count.ShouldBe(2);
+        log.MaximumLevel.ShouldBe(2);
+        log.Tick.ShouldBe(_tick);
+        log.MergeRates.Data.First().ShouldBe(new MergeRate
+        {
+            Level = 1,
+            Rate = 5
+        });
+        log.MergeRates.Data.Last().ShouldBe(new MergeRate
+        {
+            Level = 2,
+            Rate = 5
+        });
+
+        var output = await SchrodingerContractStub.GetMergeConfig.CallAsync(new StringValue { Value = _tick });
+        output.Tick.ShouldBe(_tick);
+        output.MaximumLevel.ShouldBe(2);
+        output.MergeRates.ShouldBe(log.MergeRates);
+    }
+
+    [Fact]
+    public async Task SetMergeRatesConfigTests_Fail()
+    {
+        await DeployTest();
+
+        var result =
+            await SchrodingerContractStub.SetMergeRatesConfig.SendWithExceptionAsync(new SetMergeRatesConfigInput());
+        result.TransactionResult.Error.ShouldContain("Invalid tick.");
+
+        result = await SchrodingerContractStub.SetMergeRatesConfig.SendWithExceptionAsync(new SetMergeRatesConfigInput
+        {
+            Tick = "test"
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid merge rates.");
+
+        result = await SchrodingerContractStub.SetMergeRatesConfig.SendWithExceptionAsync(new SetMergeRatesConfigInput
+        {
+            Tick = "test",
+            MergeRates =
+            {
+                new MergeRate
+                {
+                    Rate = -1
+                }
+            }
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid maximum level.");
+
+        result = await SchrodingerContractStub.SetMergeRatesConfig.SendWithExceptionAsync(new SetMergeRatesConfigInput
+        {
+            Tick = "test",
+            MergeRates =
+            {
+                new MergeRate
+                {
+                    Rate = -1
+                }
+            },
+            MaximumLevel = 1
+        });
+        result.TransactionResult.Error.ShouldContain("Inscription not found.");
+
+        result = await SchrodingerContractStub.SetMergeRatesConfig.SendWithExceptionAsync(new SetMergeRatesConfigInput
+        {
+            Tick = _tick,
+            MergeRates =
+            {
+                new MergeRate
+                {
+                    Rate = -1
+                }
+            },
+            MaximumLevel = 1
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid merge rate.");
+
+        result = await UserSchrodingerContractStub.SetMergeRatesConfig.SendWithExceptionAsync(
+            new SetMergeRatesConfigInput
+            {
+                Tick = _tick,
+                MergeRates =
+                {
+                    new MergeRate
+                    {
+                        Rate = 0
+                    }
+                },
+                MaximumLevel = 1
+            });
+        result.TransactionResult.Error.ShouldContain("No permission.");
+    }
+
+    [Fact]
+    public async Task SetMergeConfigTests()
+    {
+        await DeployTest();
+
+        var result = await SchrodingerContractStub.SetMergeConfig.SendAsync(new SetMergeConfigInput
+        {
+            Tick = _tick,
+            CommissionAmount = 100,
+            PoolAmount = 100
+        });
+        result.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
+
+        var log = GetLogEvent<MergeConfigSet>(result.TransactionResult);
+        log.Tick.ShouldBe(_tick);
+        log.Config.CommissionAmount.ShouldBe(100);
+        log.Config.PoolAmount.ShouldBe(100);
+
+        var output = await SchrodingerContractStub.GetMergeConfig.CallAsync(new StringValue { Value = _tick });
+        output.Tick.ShouldBe(_tick);
+        output.Config.ShouldBe(log.Config);
+    }
+
+    [Fact]
+    public async Task SetMergeConfigTests_Fail()
+    {
+        await DeployTest();
+
+        var result = await SchrodingerContractStub.SetMergeConfig.SendWithExceptionAsync(new SetMergeConfigInput());
+        result.TransactionResult.Error.ShouldContain("Invalid tick.");
+
+        result = await SchrodingerContractStub.SetMergeConfig.SendWithExceptionAsync(new SetMergeConfigInput
+        {
+            Tick = "test",
+            CommissionAmount = -1
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid commission amount.");
+
+        result = await SchrodingerContractStub.SetMergeConfig.SendWithExceptionAsync(new SetMergeConfigInput
+        {
+            Tick = "test",
+            PoolAmount = -1
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid pool amount.");
+
+        result = await SchrodingerContractStub.SetMergeConfig.SendWithExceptionAsync(new SetMergeConfigInput
+        {
+            Tick = "test"
+        });
+        result.TransactionResult.Error.ShouldContain("Inscription not found.");
+
+        result = await UserSchrodingerContractStub.SetMergeConfig.SendWithExceptionAsync(new SetMergeConfigInput
+        {
+            Tick = _tick
+        });
+        result.TransactionResult.Error.ShouldContain("No permission.");
+    }
+
+    [Fact]
+    public async Task MergeTests()
+    {
+        var sgr = $"{_tick}-1";
+        Hash symbolAId;
+        Hash symbolBId;
+        string symbolA;
+        string symbolB;
+        Hash adoptInfoAId;
+        Hash adoptInfoBId;
+
+        await PrepareForMergeTests();
+
+        {
+            await TokenContractStub.Issue.SendAsync(new IssueInput
+            {
+                Amount = 1_60000000,
+                Symbol = sgr,
+                To = DefaultAddress
+            });
+            await TokenContractStub.Approve.SendAsync(new ApproveInput
+            {
+                Amount = 1_60000000,
+                Symbol = sgr,
+                Spender = SchrodingerContractAddress
+            });
+            var result = await SchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
+            {
+                Amount = 1_60000000,
+                Domain = "test",
+                Tick = _tick
+            });
+            var log = GetLogEvent<Adopted>(result.TransactionResult);
+            log.LossAmount.ShouldBe(0_55000000);
+            log.CommissionAmount.ShouldBe(0_55000000);
+            log.OutputAmount.ShouldBe(1_00000000);
+
+            symbolAId = log.AdoptId;
+            symbolA = log.Symbol;
+
+            await SchrodingerContractStub.Confirm.SendAsync(new ConfirmInput
+            {
+                AdoptId = symbolAId,
+                Image = "image",
+                ImageUri = "uri",
+                Signature = GenerateSignature(DefaultKeyPair.PrivateKey, symbolAId, "image", "uri")
+            });
+
+            var balance = await GetTokenBalance(symbolA, DefaultAddress);
+            balance.ShouldBe(1_00000000);
+
+            await TokenContractStub.Approve.SendAsync(new ApproveInput
+            {
+                Amount = 1_00000000,
+                Symbol = symbolA,
+                Spender = SchrodingerContractAddress
+            });
+        }
+
+        {
+            await TokenContractStub.Issue.SendAsync(new IssueInput
+            {
+                Amount = 3_20000000,
+                Symbol = sgr,
+                To = DefaultAddress
+            });
+            await TokenContractStub.Approve.SendAsync(new ApproveInput
+            {
+                Amount = 3_20000000,
+                Symbol = sgr,
+                Spender = SchrodingerContractAddress
+            });
+            var result = await SchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
+            {
+                Amount = 3_20000000,
+                Domain = "test",
+                Tick = _tick
+            });
+
+            var log = GetLogEvent<Adopted>(result.TransactionResult);
+            log.OutputAmount.ShouldBe(2_00000000);
+
+            symbolBId = log.AdoptId;
+            symbolB = log.Symbol;
+
+            await SchrodingerContractStub.Confirm.SendAsync(new ConfirmInput
+            {
+                AdoptId = symbolBId,
+                Image = "image",
+                ImageUri = "uri",
+                Signature = GenerateSignature(DefaultKeyPair.PrivateKey, symbolBId, "image", "uri")
+            });
+
+            var balance = await GetTokenBalance(symbolB, DefaultAddress);
+            balance.ShouldBe(2_00000000);
+
+            await TokenContractStub.Approve.SendAsync(new ApproveInput
+            {
+                Amount = 2_00000000,
+                Symbol = symbolB,
+                Spender = SchrodingerContractAddress
+            });
+        }
+
+        {
+            await TokenContractStub.Issue.SendAsync(new IssueInput
+            {
+                Amount = 1_60000000,
+                Symbol = sgr,
+                To = DefaultAddress
+            });
+            await TokenContractStub.Approve.SendAsync(new ApproveInput
+            {
+                Amount = 1_60000000,
+                Symbol = sgr,
+                Spender = SchrodingerContractAddress
+            });
+            var result = await SchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
+            {
+                Amount = 1_60000000,
+                Domain = "test",
+                Tick = _tick
+            });
+            var log = GetLogEvent<Adopted>(result.TransactionResult);
+            adoptInfoAId = log.AdoptId;
+        }
+
+        {
+            await TokenContractStub.Issue.SendAsync(new IssueInput
+            {
+                Amount = 3_20000000,
+                Symbol = sgr,
+                To = DefaultAddress
+            });
+            await TokenContractStub.Approve.SendAsync(new ApproveInput
+            {
+                Amount = 3_20000000,
+                Symbol = sgr,
+                Spender = SchrodingerContractAddress
+            });
+            var result = await SchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
+            {
+                Amount = 3_20000000,
+                Domain = "test",
+                Tick = _tick
+            });
+
+            var log = GetLogEvent<Adopted>(result.TransactionResult);
+            log.OutputAmount.ShouldBe(2_00000000);
+            adoptInfoBId = log.AdoptId;
+        }
+
+        // token x token
+        {
+            var result = await SchrodingerContractStub.Merge.SendAsync(new MergeInput
+            {
+                Tick = _tick,
+                Level = 1,
+                AdoptIdA = symbolAId,
+                AdoptIdB = symbolBId,
+                Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, symbolAId, symbolBId, 1)
+            });
+
+            var log = GetLogEvent<Merged>(result.TransactionResult);
+            log.Tick.ShouldBe(_tick);
+            log.AdoptIdA.ShouldBe(symbolAId);
+            log.AdoptIdB.ShouldBe(symbolBId);
+            log.AmountA.ShouldBe(0);
+            log.AmountB.ShouldBe(1_00000000);
+            log.SymbolA.ShouldBe($"{_tick}-2");
+            log.SymbolB.ShouldBe($"{_tick}-3");
+            log.LossAmount.ShouldBe(0_25000000);
+            log.CommissionAmount.ShouldBe(0_25000000);
+            log.AdoptInfo.Adopter.ShouldBe(DefaultAddress);
+            log.AdoptInfo.InputAmount.ShouldBe(2_00000000);
+            log.AdoptInfo.OutputAmount.ShouldBe(1_00000000);
+            log.AdoptInfo.ImageCount.ShouldBe(2);
+            log.AdoptInfo.BlockHeight.ShouldBe(result.TransactionResult.BlockNumber);
+            log.AdoptInfo.Symbol.ShouldBe($"{_tick}-6");
+            log.AdoptInfo.TokenName.ShouldBe($"{_tick}-6GEN9");
+            log.AdoptInfo.Attributes.Data.Count.ShouldBe(11);
+            log.AdoptInfo.Gen.ShouldBe(9);
+            log.AdoptInfo.IsConfirmed.ShouldBeFalse();
+            log.AdoptInfo.IsRerolled.ShouldBeFalse();
+            log.AdoptInfo.IsUpdated.ShouldBeFalse();
+            log.AdoptInfo.Level.ShouldBe(2);
+
+            var balance = await GetTokenBalance(symbolA, DefaultAddress);
+            balance.ShouldBe(0);
+            balance = await GetTokenBalance(symbolB, DefaultAddress);
+            balance.ShouldBe(1_00000000);
+
+            var adoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(log.AdoptInfo.AdoptId);
+            adoptInfo.ShouldBe(log.AdoptInfo);
+
+            await SchrodingerContractStub.Confirm.SendAsync(new ConfirmInput
+            {
+                AdoptId = adoptInfo.AdoptId,
+                ImageUri = "uri",
+                Image = "image",
+                Signature = GenerateSignature(DefaultKeyPair.PrivateKey, adoptInfo.AdoptId, "image", "uri")
+            });
+        }
+
+        {
+            var result = await SchrodingerContractStub.Merge.SendAsync(new MergeInput
+            {
+                Tick = _tick,
+                Level = 1,
+                AdoptIdA = symbolBId,
+                AdoptIdB = adoptInfoBId,
+                Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, symbolBId, adoptInfoBId, 1)
+            });
+
+            var log = GetLogEvent<Merged>(result.TransactionResult);
+            log.AdoptIdA.ShouldBe(symbolBId);
+            log.AdoptIdB.ShouldBe(adoptInfoBId);
+            var balance = await GetTokenBalance(symbolB, DefaultAddress);
+            balance.ShouldBe(0);
+
+            var adoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(adoptInfoBId);
+            adoptInfo.OutputAmount.ShouldBe(1_00000000);
+        }
+
+        {
+            var result = await SchrodingerContractStub.Merge.SendAsync(new MergeInput
+            {
+                Tick = _tick,
+                Level = 1,
+                AdoptIdA = adoptInfoAId,
+                AdoptIdB = adoptInfoBId,
+                Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, adoptInfoAId, adoptInfoBId, 1)
+            });
+
+            var log = GetLogEvent<Merged>(result.TransactionResult);
+            log.AdoptIdA.ShouldBe(adoptInfoAId);
+            log.AdoptIdB.ShouldBe(adoptInfoBId);
+
+            var adoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(adoptInfoAId);
+            adoptInfo.OutputAmount.ShouldBe(0);
+
+            adoptInfo = await SchrodingerContractStub.GetAdoptInfo.CallAsync(adoptInfoBId);
+            adoptInfo.OutputAmount.ShouldBe(0);
+        }
+    }
+
+    [Fact]
+    public async Task MergeTests_Fail()
+    {
+        await PrepareForMergeTests();
+
+        var result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput());
+        result.TransactionResult.Error.ShouldContain("Invalid tick.");
+
+        result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = "test"
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid adopt id a.");
+
+        result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = "test",
+            AdoptIdA = HashHelper.ComputeFrom("test")
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid adopt id b.");
+
+        result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = "test",
+            AdoptIdA = HashHelper.ComputeFrom("test"),
+            AdoptIdB = HashHelper.ComputeFrom("test")
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid level.");
+
+        result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = "test",
+            AdoptIdA = HashHelper.ComputeFrom("test"),
+            AdoptIdB = HashHelper.ComputeFrom("test"),
+            Level = 1
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid signature.");
+
+        result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = "test",
+            AdoptIdA = HashHelper.ComputeFrom("test"),
+            AdoptIdB = HashHelper.ComputeFrom("test"),
+            Level = 1,
+            Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, HashHelper.ComputeFrom("test"),
+                HashHelper.ComputeFrom("test"), 1)
+        });
+        result.TransactionResult.Error.ShouldContain("Invalid signature.");
+        
+        result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = _tick,
+            AdoptIdA = HashHelper.ComputeFrom("test"),
+            AdoptIdB = HashHelper.ComputeFrom("test"),
+            Level = 5,
+            Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, HashHelper.ComputeFrom("test"),
+                HashHelper.ComputeFrom("test"), 5)
+        });
+        result.TransactionResult.Error.ShouldContain("Already reach maximum level.");
+        
+        result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = _tick,
+            AdoptIdA = HashHelper.ComputeFrom("test"),
+            AdoptIdB = HashHelper.ComputeFrom("test"),
+            Level = 1,
+            Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, HashHelper.ComputeFrom("test"),
+                HashHelper.ComputeFrom("test"), 1)
+        });
+        result.TransactionResult.Error.ShouldContain("not found.");
+        
+        var adoptId = await AdoptMaxGen();
+        
+        var adoptIdA = await AdoptMaxGen();
+        await SchrodingerContractStub.RerollAdoption.SendAsync(adoptIdA);
+        result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = _tick,
+            AdoptIdA = adoptId,
+            AdoptIdB = adoptIdA,
+            Level = 1,
+            Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, adoptId, adoptIdA, 1)
+        });
+        result.TransactionResult.Error.ShouldContain("already rerolled.");
+        
+        // adoptIdA = await AdoptTest();
+        // result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        // {
+        //     Tick = _tick,
+        //     AdoptIdA = adoptId,
+        //     AdoptIdB = adoptIdA,
+        //     Level = 1,
+        //     Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, adoptId, adoptIdA, 1)
+        // });
+        // result.TransactionResult.Error.ShouldContain("not reach max generation.");
+        
+        adoptIdA = await AdoptMaxGen();
+        result = await UserSchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = _tick,
+            AdoptIdA = adoptId,
+            AdoptIdB = adoptIdA,
+            Level = 1,
+            Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, adoptId, adoptIdA, 1)
+        });
+        result.TransactionResult.Error.ShouldContain("No permission.");
+        
+        result = await SchrodingerContractStub.Merge.SendAsync(new MergeInput
+        {
+            Tick = _tick,
+            AdoptIdA = adoptId,
+            AdoptIdB = adoptIdA,
+            Level = 1,
+            Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, adoptId, adoptIdA, 1)
+        });
+
+        var adoptIdB = GetLogEvent<Merged>(result.TransactionResult).AdoptInfo.AdoptId;
+        
+        result = await SchrodingerContractStub.Merge.SendWithExceptionAsync(new MergeInput
+        {
+            Tick = _tick,
+            AdoptIdA = adoptId,
+            AdoptIdB = adoptIdB,
+            Level = 1,
+            Signature = GenerateSignature(DefaultKeyPair.PrivateKey, _tick, adoptId, adoptIdB, 1)
+        });
+        result.TransactionResult.Error.ShouldContain("Level not matched.");
+    }
+
+    private async Task PrepareForMergeTests()
+    {
+        await DeployForMaxGen();
+        await SchrodingerContractStub.SetRates.SendAsync(new SetRatesInput
+        {
+            Tick = _tick,
+            CommissionRate = 5000,
+            LossRate = 5285,
+            MaxGenLossRate = 6875
+        });
+        await SchrodingerContractStub.SetMergeConfig.SendAsync(new SetMergeConfigInput
+        {
+            Tick = _tick,
+            CommissionAmount = 25000000,
+            PoolAmount = 25000000
+        });
+        await SchrodingerContractStub.SetMergeRatesConfig.SendAsync(new SetMergeRatesConfigInput
+        {
+            Tick = _tick,
+            MaximumLevel = 3,
+            MergeRates =
+            {
+                new MergeRate
+                {
+                    Level = 1,
+                    Rate = 10000
+                }
+            }
+        });
+        await SchrodingerContractStub.SetRerollConfig.SendAsync(new SetRerollConfigInput
+        {
+            Tick = _tick,
+            Index = 2,
+            Rate = 5000
+        });
+    }
+
+    private ByteString GenerateSignature(byte[] privateKey, string tick, Hash a, Hash b, long level)
+    {
+        var data = new MergeInput
+        {
+            Tick = tick,
+            AdoptIdA = a,
+            AdoptIdB = b,
+            Level = level
+        };
+        var dataHash = HashHelper.ComputeFrom(data);
+        var signature = CryptoHelper.SignWithPrivateKey(privateKey, dataHash.ToByteArray());
+        return ByteStringHelper.FromHexString(signature.ToHex());
+    }
+
+    private async Task<Hash> AdoptMaxGen()
+    {
+        await TokenContractStub.Issue.SendAsync(new IssueInput
+        {
+            Amount = 3_20000000,
+            Symbol = $"{_tick}-1",
+            To = DefaultAddress
+        });
+        await TokenContractStub.Approve.SendAsync(new ApproveInput
+        {
+            Amount = 3_20000000,
+            Symbol = $"{_tick}-1",
+            Spender = SchrodingerContractAddress
+        });
+        var result = await SchrodingerContractStub.AdoptMaxGen.SendAsync(new AdoptMaxGenInput
+        {
+            Amount = 3_20000000,
+            Domain = "test",
+            Tick = _tick
+        });
+        var log = GetLogEvent<Adopted>(result.TransactionResult);
+        return log.AdoptId;
+    }
+    
+    // private async Task<Hash> AdoptTest()
+    // {
+    //     await TokenContractStub.Issue.SendAsync(new IssueInput
+    //     {
+    //         Symbol = Gen0,
+    //         Amount = 2_00000000,
+    //         To = DefaultAddress
+    //     });
+    //
+    //     await TokenContractStub.Approve.SendAsync(new ApproveInput
+    //     {
+    //         Symbol = Gen0,
+    //         Amount = 2_00000000,
+    //         Spender = SchrodingerContractAddress
+    //     });
+    //
+    //     var result = await SchrodingerContractStub.Adopt.SendAsync(new AdoptInput
+    //     {
+    //         Parent = Gen0,
+    //         Amount = 2_00000000,
+    //         Domain = "test"
+    //     });
+    //
+    //     return GetLogEvent<Adopted>(result.TransactionResult).AdoptId;
+    // }
+}


### PR DESCRIPTION
1. Implement RerollConfig for configuring the reroll exchange ratio.
2. Develop the Merge feature, which allows users to combine two tokens or Cat boxes of the same level to create a higher-level Cat box.
3. Added configuration options for success rates for merges at different levels.
4. Redesigned the calculation method for fees and prize pool income, transitioning from a percentage-based system to a fixed value model for a more predictable income structure.
5. Disabled the Adopt and UpdateAdoption interfaces.
close #24 